### PR TITLE
Adding the first draft of the AT-Community-Slack-CODE-OF-CONDUCT

### DIFF
--- a/AT-COMMUNITY-CODE-OF-CONDUCT.md
+++ b/AT-COMMUNITY-CODE-OF-CONDUCT.md
@@ -1,0 +1,86 @@
+# Algeria Tech Community Slack - Code of Conduct
+
+## TL;DR
+
+* Be respectful of others
+* Do not harass others
+* Do not share personal information of others to people outside the community
+* Do not divulge privileged information of any company, to anyone in our team
+* Don't spam the channels with links, or links to pages, for the purpose of monetization of user views and which provide no value to the ZA Developer community
+* Select channels are publicly provided and present, select and join the one that suite you best.
+
+
+Acting according to our code of conduct should not leave you in an embarrassing situation. That said, be careful never to divulge any personal or confidential information in Slack. Apart from the public archiving we have no control over how anybody else in the team could be logging and using the information provided by anyone else.
+
+This is a safe space, lets keep it that way.
+
+## Code of Conduct
+
+“AT Community” in this document refers to the  at [https://algeriatech.now.sh](Algeria Tech Community Slack organization).
+
+AT Community is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all AT Community spaces, including public channels, private channels and direct messages, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the administrators.
+
+
+Harassment includes:
+
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+* Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate
+* Threats of violence
+* Deliberate intimidation
+* Stalking or following
+* Harassing photography or recording, including logging online activity for harassment purposes
+* Sustained disruption of discussion
+* Unwelcome sexual attention
+* Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+* Continued one-on-one communication after requests to cease
+* Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse
+* Publication of non-harassing private communication
+
+Or in another word, **DON'T BE A JERK**.
+
+## Slack Channels
+
+Within AT Community slack channels we do have some given channels which will mention that have a special specificity
+in term of posting members and nature of published materials :
+
+1. [#announcements](https://algeriatech.slack.com/messages/announcements/) : This is announcements only section, typically but not exclusively dedicated for the [Admins](https://algeriatech.slack.com/team) of AT Community activities, and related community diverse in kind and feel news.
+
+2. [#chkoun](https://algeriatech.slack.com/messages/chkoun/) : This is a **NEW MEMBERS ONLY** section, where typically
+new comers, members introduce themselves (typically name and profession), therefor, any out of the scope of this channel will ported to the other channels (typical [#blabla](https://algeriatech.slack.com/messages/blabla/) for diverse in look and feel conversation that respect the rules mentioned above.)
+
+3. Other AT Community Slack Space, are divided depending on the Theme, Subject, Stack of Technology. in case you didn't find any appealing channel, advice to request it from one of the [Admins](https://algeriatech.slack.com/team) of AT Community.
+
+## Reporting
+
+If you are being harassed by a member of AT Community, notice that someone else is being harassed, or have any other concerns, please [contact an admin](https://algeriatech.slack.com/team) - You need to be a member first - directly via DM. Administrators will respond as soon as they are able. If the person who is harassing you is on the admin team, they will recuse themselves from handling your incident.
+
+This code of conduct applies to AT Community spaces, but if you are being harassed by a member of AT Community outside of our spaces, we still want to know about it. We will take all good-faith reports of harassment by AT Community members, especially the administrators, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from AT Community based on their past behavior, including behavior outside AT Community spaces and behavior towards people who are not members of the AT Community.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of AT Community members or the general public. We will not name harassment victims without their affirmative consent.
+
+Also, advice that the report should needs to a prove, we won't accept any kind of non-proven reports.
+
+A regular report should come with nothing less then : a non-edited images/screenshots which prove the act of abuse.
+
+## Consequences
+
+1.In case the [contact an admin](https://algeriatech.slack.com/team) - You need to be a member first -, find that a subject is inappropriate or misleading, or event an article that threaten the security of AT Community members, the [contact an admin](https://algeriatech.slack.com/team) will in-fact remove the given messages, articles, and provide
+the publishers of such content with the given appropriate answer or such act.
+
+2.Participants asked to stop any harassing behavior are expected to comply immediately.
+
+3.If a participant engages in harassing behavior, the administrators may take any action they deem appropriate, up to and including expulsion from all AT Community spaces and identification of the participant as a harasser to other AT Community members and/or the general public.
+
+
+## Changes
+This code of conduct is subject to change as circumstances require, all current members of the AT Community will be notified through the [#announcements](https://algeriatech.slack.com/messages/announcements/) channel prior to these changes taking effect.
+
+
+## Credits
+
+This Code of Conduct is heavily based on the [zadev](https://github.com/zadev/code-of-conduct/blob/master/README.md)


### PR DESCRIPTION
As reported over #10, this is the first draft of the AT-Community Slack channel CODE-OF-CONDUCT, please advice this CODE-OF-CONDUCT will manage the life of the channel, and will disallow abuse/harassment or any kind of activities.