### PR TITLE
Adding lockdoor framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A curated list of awesome things and projects built by Algerian developers.
   - [Facial-expression-recognition-svm](https://github.com/amineHorseman/facial-expression-recognition-svm) - Training SVM classifier to recognize facial expressions (emotions)
   - [Malware Revealer](https://github.com/malware-revealer/malware-revealer) - A malware classification framework, designed primarily for malware detection, it contains a modular toolset for feature extraction, as well as pre-trained models and a ready to use web API for making predictions.
   - [Tchamba.random](https://github.com/Fcmam5/tchamba) package of functions generating random data (colors, names, jokes, letters..)
+  - [Lockdoor Framework ](https://github.com/SofianeHamlaoui/Lockdoor-Framework) -  A Penetration Testing framework with Cyber Security Resources
 - ROS
   - [Pionner bringup](https://github.com/amineHorseman/pioneer_bringup) A ROS package providing ROS launch scripts for starting the Adept MobileRobots Pioneer and Pioneer-compatible robots
   - [Pionner teleop](https://github.com/amineHorseman/pioneer_teleop) A ROS package providing scripts for teleoperation (using keyboard, web sockets, command line or xbox360 controller) to all Adept MobileRobots Pioneer and Pioneer-compatible robots


### PR DESCRIPTION
LockDoor is a Framework aimed at helping penetration testers, bug bounty hunters And cyber security engineers. 
This tool is designed for Debian/Ubuntu/ArchLinux based distributions to create a similar and familiar distribution for Penetration Testing. 
But containing the favorite and the most used tools by Pentesters. 
As pentesters, most of us has his personal ' /pentest/ ' directory so this Framework is helping you to build a perfect one. 
With all of that ! It automates the Pentesting process to help you do the job more quickly and easily.
Link : https://lockdoor.sofianehamlaoui.me